### PR TITLE
Add notes importer for logseq processing

### DIFF
--- a/notes_importer.py
+++ b/notes_importer.py
@@ -84,8 +84,9 @@ def main() -> None:
     for md in md_files:
         process_markdown(md, journals_dir_one, assets_dir_one)
 
-    cmd = ["longdown", "-d", str(journals_dir_two)] + [str(p) for p in journals_dir_one.glob("*.md")]
-    subprocess.run(cmd, check=True)
+    md_files = [p.name for p in journals_dir_one.glob("*.md")]
+    cmd = ["longdown", "-d", str(journals_dir_two)] + md_files
+    subprocess.run(cmd, check=True, cwd=journals_dir_one)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `notes_importer.py` to scan markdown notes and attachments
- convert embedded base64 images to Logseq image links with copied assets
- run `longdown` to transform notes into Logseq outline format
- invoke `longdown` from the journals directory so only filenames are passed

## Testing
- `python -m py_compile notes_importer.py`
- `python notes_importer.py --input-folder . --intermediary-dir-one /tmp/i1 --intermediary-dir-two /tmp/i2 --dry-run`
- `python notes_importer.py --input-folder . --intermediary-dir-one /tmp/i1 --intermediary-dir-two /tmp/i2` *(fails: longdown not found)*
- `pip install longdown` *(fails: No matching distribution found for longdown)*

------
https://chatgpt.com/codex/tasks/task_e_68a2072824c48333850d022a9d78689b