### PR TITLE
Add `auto` subcommand to run full notes import pipeline

### DIFF
--- a/notes_importer.py
+++ b/notes_importer.py
@@ -127,6 +127,35 @@ def cmd_append_to_logseq(args: argparse.Namespace) -> None:
                 shutil.copy2(asset, logseq_assets_dir / asset.name)
 
 
+def cmd_auto(args: argparse.Namespace) -> None:
+    """Run the full import pipeline: process-images -> longdown -> append-to-logseq."""
+    input_dir = Path(args.input_dir)
+    staging_dir = Path(args.staging_dir)
+    logseq_dir = Path(args.logseq_dir)
+
+    cmd_process_images(
+        argparse.Namespace(
+            input_dir=str(input_dir),
+            output_dir=str(staging_dir),
+        )
+    )
+
+    cmd_longdown(
+        argparse.Namespace(
+            input_dir=str(staging_dir / "processed_markdown"),
+            output_dir=str(staging_dir / "longdown"),
+        )
+    )
+
+    cmd_append_to_logseq(
+        argparse.Namespace(
+            input_dir=str(staging_dir / "longdown"),
+            logseq_dir=str(logseq_dir),
+            assets_dir=str(staging_dir / "assets"),
+        )
+    )
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="Import notes into Logseq")
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -146,6 +175,15 @@ def main() -> None:
     append_parser.add_argument("--logseq-dir", required=True, help="Root Logseq directory")
     append_parser.add_argument("--assets-dir", required=True, help="Directory containing assets to copy")
     append_parser.set_defaults(func=cmd_append_to_logseq)
+
+    auto_parser = subparsers.add_parser(
+        "auto",
+        help="Run process-images, longdown, and append-to-logseq in sequence",
+    )
+    auto_parser.add_argument("--input-dir", required=True, help="Directory containing markdown files")
+    auto_parser.add_argument("--logseq-dir", required=True, help="Root Logseq directory")
+    auto_parser.add_argument("--staging-dir", required=True, help="Directory used for intermediate output")
+    auto_parser.set_defaults(func=cmd_auto)
 
     args = parser.parse_args()
     args.func(args)

--- a/tests/notes_dir/2026-01-15 note Attachments/inline-image.bin
+++ b/tests/notes_dir/2026-01-15 note Attachments/inline-image.bin
@@ -1,0 +1,1 @@
+fake-image-bytes-1

--- a/tests/notes_dir/2026-01-15 note.md
+++ b/tests/notes_dir/2026-01-15 note.md
@@ -1,0 +1,5 @@
+# Daily Note 1
+
+Some note content before image.
+
+<img src="data:image/png;base64,ZmFrZS1pbWFnZS1ieXRlcy0x" />

--- a/tests/notes_dir/2026-01-16 note Attachments/inline-image-two.bin
+++ b/tests/notes_dir/2026-01-16 note Attachments/inline-image-two.bin
@@ -1,0 +1,1 @@
+fake-image-bytes-2

--- a/tests/notes_dir/2026-01-16 note.md
+++ b/tests/notes_dir/2026-01-16 note.md
@@ -1,0 +1,5 @@
+# Daily Note 2
+
+Some note content before image.
+
+<img src="data:image/png;base64,ZmFrZS1pbWFnZS1ieXRlcy0y" />

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -1,0 +1,35 @@
+import argparse
+import shutil
+import unittest
+from pathlib import Path
+
+from notes_importer import cmd_auto
+
+
+class TestNotesImporterAuto(unittest.TestCase):
+    def test_cmd_auto_creates_expected_logseq_journals(self) -> None:
+        root = Path(__file__).resolve().parent
+        notes_dir = root / "notes_dir"
+        staging_dir = root / "staging_dir"
+        logseq_dir = root / "logseq_dir"
+
+        if staging_dir.exists():
+            shutil.rmtree(staging_dir)
+        if logseq_dir.exists():
+            shutil.rmtree(logseq_dir)
+
+        cmd_auto(
+            argparse.Namespace(
+                input_dir=str(notes_dir),
+                staging_dir=str(staging_dir),
+                logseq_dir=str(logseq_dir),
+            )
+        )
+
+        self.assertTrue((logseq_dir / "journals" / "2026_01_15.md").exists())
+        self.assertTrue((logseq_dir / "journals" / "2026_01_16.md").exists())
+        self.assertTrue((logseq_dir / "assets" / "2026-01-15 note---inline-image.bin").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -30,6 +30,10 @@ class TestNotesImporterAuto(unittest.TestCase):
         self.assertTrue((logseq_dir / "journals" / "2026_01_16.md").exists())
         self.assertTrue((logseq_dir / "assets" / "2026-01-15 note---inline-image.bin").exists())
 
+        # cleanup 
+        shutil.rmtree(logseq_dir)
+        shutil.rmtree(staging_dir)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Motivation
- Provide a single CLI entrypoint to run the three-step import flow (`process-images` → `longdown` → `append-to-logseq`) so users can run the full pipeline with one command and minimal wiring of paths.

### Description
- Add `cmd_auto(args: argparse.Namespace)` which invokes the existing `cmd_process_images`, `cmd_longdown`, and `cmd_append_to_logseq` functions in sequence using constructed `argparse.Namespace` objects for each step.
- Wire the `auto` subcommand into the CLI with required flags `--input-dir`, `--staging-dir`, and `--logseq-dir` and set its handler to `cmd_auto`.
- The pipeline maps `--input-dir` to `process-images --input-dir`, uses `--staging-dir` as `process-images --output-dir`, then uses `staging_dir/processed_markdown` → `staging_dir/longdown` for `longdown`, and finally imports from `staging_dir/longdown` with assets from `staging_dir/assets` into `--logseq-dir` for `append-to-logseq`.
- No behavioral changes were made to the existing `process-images`, `longdown`, or `append-to-logseq` commands.

### Testing
- Ran `python notes_importer.py --help` and confirmed the `auto` subcommand is listed and its options are shown (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffb5a7a558833387be805ce27426b4)