### PR TITLE
Convert HEIC/HEIF attachments to JPEG when processing images

### DIFF
--- a/notes_importer.py
+++ b/notes_importer.py
@@ -44,15 +44,34 @@ def process_markdown(src_md: Path, dst_journals: Path, dst_assets: Path) -> None
 
     pattern = re.compile(r'<img[^>]+src="data:image/[^;]+;base64,([^\"]+)"[^>]*/>')
 
+    def copy_or_convert_attachment(attachment: Path, asset_name_base: str) -> str:
+        if attachment.suffix.lower() not in {".heic", ".heif"}:
+            asset_name = f"{asset_name_base}{attachment.suffix}"
+            shutil.copy2(attachment, dst_assets / asset_name)
+            return asset_name
+
+        asset_name = f"{asset_name_base}.jpeg"
+        asset_path = dst_assets / asset_name
+        try:
+            subprocess.run(
+                ["sips", "-s", "format", "jpeg", str(attachment), "--out", str(asset_path)],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except (FileNotFoundError, subprocess.CalledProcessError):
+            fallback_name = f"{asset_name_base}{attachment.suffix}"
+            shutil.copy2(attachment, dst_assets / fallback_name)
+            return fallback_name
+        return asset_name
+
     def replace_img(match: re.Match) -> str:
         b64_data = match.group(1)
         img_bytes = base64.b64decode(b64_data)
         data_hash = hashlib.md5(img_bytes).hexdigest()
         attachment = find_matching_attachment(attachments_dir, data_hash)
         if attachment:
-            asset_name = f"{base_name}---{attachment.name}"
-            asset_path = dst_assets / asset_name
-            shutil.copy2(attachment, asset_path)
+            asset_name = copy_or_convert_attachment(attachment, f"{base_name}---{attachment.stem}")
             return f"![image.png](../assets/{asset_name})"
         return match.group(0)
 

--- a/notes_importer.py
+++ b/notes_importer.py
@@ -45,6 +45,31 @@ def process_markdown(src_md: Path, dst_journals: Path, dst_assets: Path) -> None
     pattern = re.compile(r'<img[^>]+src="data:image/[^;]+;base64,([^\"]+)"[^>]*/>')
 
     def copy_or_convert_attachment(attachment: Path, asset_name_base: str) -> str:
+        """Copy ``attachment`` to assets, converting HEIC/HEIF files to JPEG.
+
+        Parameters
+        ----------
+        attachment
+            Source attachment path resolved from the Apple Notes attachments
+            directory.
+        asset_name_base
+            Base filename (without extension) to use for the destination asset
+            in ``dst_assets``.
+
+        Returns
+        -------
+        str
+            The destination asset filename (including extension) used in the
+            markdown image link.
+
+        Examples
+        --------
+        ``copy_or_convert_attachment(Path("photo.heic"), "2026-01-16---photo")``
+            Returns ``"2026-01-16---photo.jpeg"`` when conversion succeeds.
+
+        ``copy_or_convert_attachment(Path("scan.png"), "2026-01-16---scan")``
+            Returns ``"2026-01-16---scan.png"`` and copies the file as-is.
+        """
         if attachment.suffix.lower() not in {".heic", ".heif"}:
             asset_name = f"{asset_name_base}{attachment.suffix}"
             shutil.copy2(attachment, dst_assets / asset_name)

--- a/tests/test_notes_importer.py
+++ b/tests/test_notes_importer.py
@@ -104,3 +104,24 @@ def test_cmd_auto_chains_commands(monkeypatch) -> None:
     process_mock.assert_called_once_with(Path("/in"), Path("/staging"))
     longdown_mock.assert_called_once_with(Path("/staging/processed_markdown"), Path("/staging/longdown"))
     append_mock.assert_called_once_with(Path("/staging/longdown"), Path("/logseq"), Path("/staging/assets"))
+
+
+def test_process_markdown_converts_heic_attachment_to_jpeg(tmp_path: Path, monkeypatch) -> None:
+    src_md = tmp_path / "2026-01-16 note.md"
+    src_md.write_text('<img src="data:image/heic;base64,YWJj"/>')
+    attachments_dir = tmp_path / "2026-01-16 note Attachments"
+    attachments_dir.mkdir()
+    (attachments_dir / "inline-image.heic").write_bytes(b"abc")
+    dst_journals = tmp_path / "journals"
+    dst_assets = tmp_path / "assets"
+    dst_journals.mkdir()
+    dst_assets.mkdir()
+
+    run_mock = MagicMock()
+    monkeypatch.setattr(notes_importer.subprocess, "run", run_mock)
+
+    notes_importer.process_markdown(src_md, dst_journals, dst_assets)
+
+    output = (dst_journals / src_md.name).read_text()
+    assert "![image.png](../assets/2026-01-16 note---inline-image.jpeg)" in output
+    run_mock.assert_called_once()


### PR DESCRIPTION
### Motivation
- Apple Notes exports can include HEIC/HEIF attachments which are not ideal for downstream use in Logseq assets, so convert them to a more widely usable format during processing.

### Description
- Add a helper `copy_or_convert_attachment` in `notes_importer.py` that copies non-HEIC files unchanged and converts `.heic`/`.heif` files to `.jpeg` using `sips` before writing to the assets directory.
- Use the new helper from `replace_img` so processed markdown links point to the converted `.jpeg` asset name when conversion succeeds.
- Add a fallback that copies the original HEIC/HEIF file if the `sips` command is missing or the conversion fails.
- Add `test_process_markdown_converts_heic_attachment_to_jpeg` in `tests/test_notes_importer.py` to cover the HEIC conversion path and assert `subprocess.run` is invoked.

### Testing
- Ran the test suite with `pytest -q` and all tests passed (8 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17b54416548333a6ef8408d88ca6db)