### PR TITLE
Wrap markdown image destinations in angle brackets

### DIFF
--- a/notes_importer.py
+++ b/notes_importer.py
@@ -28,6 +28,60 @@ def find_matching_attachment(attachments_dir: Path, data_hash: str) -> Path | No
     return None
 
 
+def wrap_image_markdown_paths(text: str) -> str:
+    """Wrap markdown image destinations in angle brackets.
+
+    Markdown image links like ``![alt](../assets/file name (2).png)`` can
+    contain spaces and balanced parentheses in filenames. Logseq handles those
+    paths more reliably when the destination is enclosed in ``<`` and ``>``.
+    Already wrapped destinations are left unchanged.
+    """
+    output: list[str] = []
+    i = 0
+
+    while i < len(text):
+        image_start = text.find("![", i)
+        if image_start == -1:
+            output.append(text[i:])
+            break
+
+        output.append(text[i:image_start])
+        alt_end = text.find("](", image_start + 2)
+        if alt_end == -1:
+            output.append(text[image_start:])
+            break
+
+        path_start = alt_end + 2
+        depth = 0
+        path_end = path_start
+        while path_end < len(text):
+            char = text[path_end]
+            if char == "(":
+                depth += 1
+            elif char == ")":
+                if depth == 0:
+                    break
+                depth -= 1
+            path_end += 1
+
+        if path_end == len(text):
+            output.append(text[image_start:])
+            break
+
+        path = text[path_start:path_end]
+        if path.startswith("<") and path.endswith(">"):
+            wrapped_path = path
+        else:
+            wrapped_path = f"<{path}>"
+
+        output.append(text[image_start:path_start])
+        output.append(wrapped_path)
+        output.append(")")
+        i = path_end + 1
+
+    return "".join(output)
+
+
 def process_markdown(src_md: Path, dst_journals: Path, dst_assets: Path) -> None:
     """Copy ``src_md`` to ``dst_journals`` and replace embedded images.
 
@@ -53,7 +107,7 @@ def process_markdown(src_md: Path, dst_journals: Path, dst_assets: Path) -> None
             asset_name = f"{base_name}---{attachment.name}"
             asset_path = dst_assets / asset_name
             shutil.copy2(attachment, asset_path)
-            return f"![image.png](../assets/{asset_name})"
+            return wrap_image_markdown_paths(f"![image.png](../assets/{asset_name})")
         return match.group(0)
 
     new_text = re.sub(pattern, replace_img, text)

--- a/notes_importer.py
+++ b/notes_importer.py
@@ -28,58 +28,25 @@ def find_matching_attachment(attachments_dir: Path, data_hash: str) -> Path | No
     return None
 
 
+IMAGE_MARKDOWN_PATH_RE = re.compile(r"(!\[[^\]]*\]\()(<[^>]*>|(?:[^()]|\([^()]*\))*)(\))")
+
+
 def wrap_image_markdown_paths(text: str) -> str:
     """Wrap markdown image destinations in angle brackets.
 
     Markdown image links like ``![alt](../assets/file name (2).png)`` can
-    contain spaces and balanced parentheses in filenames. Logseq handles those
-    paths more reliably when the destination is enclosed in ``<`` and ``>``.
-    Already wrapped destinations are left unchanged.
+    contain spaces and parentheses in filenames. Logseq handles those paths more
+    reliably when the destination is enclosed in ``<`` and ``>``. Already
+    wrapped destinations are left unchanged.
     """
-    output: list[str] = []
-    i = 0
 
-    while i < len(text):
-        image_start = text.find("![", i)
-        if image_start == -1:
-            output.append(text[i:])
-            break
-
-        output.append(text[i:image_start])
-        alt_end = text.find("](", image_start + 2)
-        if alt_end == -1:
-            output.append(text[image_start:])
-            break
-
-        path_start = alt_end + 2
-        depth = 0
-        path_end = path_start
-        while path_end < len(text):
-            char = text[path_end]
-            if char == "(":
-                depth += 1
-            elif char == ")":
-                if depth == 0:
-                    break
-                depth -= 1
-            path_end += 1
-
-        if path_end == len(text):
-            output.append(text[image_start:])
-            break
-
-        path = text[path_start:path_end]
+    def wrap_path(match: re.Match) -> str:
+        prefix, path, suffix = match.groups()
         if path.startswith("<") and path.endswith(">"):
-            wrapped_path = path
-        else:
-            wrapped_path = f"<{path}>"
+            return match.group(0)
+        return f"{prefix}<{path}>{suffix}"
 
-        output.append(text[image_start:path_start])
-        output.append(wrapped_path)
-        output.append(")")
-        i = path_end + 1
-
-    return "".join(output)
+    return IMAGE_MARKDOWN_PATH_RE.sub(wrap_path, text)
 
 
 def process_markdown(src_md: Path, dst_journals: Path, dst_assets: Path) -> None:

--- a/tests/test_notes_importer.py
+++ b/tests/test_notes_importer.py
@@ -36,7 +36,7 @@ def test_process_markdown_replaces_embedded_image_and_copies_attachment(tmp_path
     notes_importer.process_markdown(src_md, dst_journals, dst_assets)
 
     output = (dst_journals / src_md.name).read_text()
-    assert "![image.png](../assets/2026-01-16 note---inline-image.bin)" in output
+    assert "![image.png](<../assets/2026-01-16 note---inline-image.bin>)" in output
     assert (dst_assets / "2026-01-16 note---inline-image.bin").exists()
 
 
@@ -104,3 +104,23 @@ def test_cmd_auto_chains_commands(monkeypatch) -> None:
     process_mock.assert_called_once_with(Path("/in"), Path("/staging"))
     longdown_mock.assert_called_once_with(Path("/staging/processed_markdown"), Path("/staging/longdown"))
     append_mock.assert_called_once_with(Path("/staging/longdown"), Path("/logseq"), Path("/staging/assets"))
+
+
+def test_wrap_image_markdown_paths_wraps_spaces_parentheses_and_plain_paths() -> None:
+    text = "\n".join([
+        "![image.png](../assets/some image with spaces.png)",
+        "![image.png](../assets/some other image okay (2).jpeg)",
+        "![image.png](../assets/blah-image-no-spaces-213.png)",
+    ])
+
+    assert notes_importer.wrap_image_markdown_paths(text) == "\n".join([
+        "![image.png](<../assets/some image with spaces.png>)",
+        "![image.png](<../assets/some other image okay (2).jpeg>)",
+        "![image.png](<../assets/blah-image-no-spaces-213.png>)",
+    ])
+
+
+def test_wrap_image_markdown_paths_leaves_already_wrapped_paths_unchanged() -> None:
+    text = "before ![image.png](<../assets/already wrapped (2).png>) after"
+
+    assert notes_importer.wrap_image_markdown_paths(text) == text


### PR DESCRIPTION
### Motivation
- Logseq can mis-handle image links whose filenames contain spaces or parentheses unless the destination is enclosed in angle brackets, so exported/processed markdown should emit bracketed paths.
- The importer currently emits asset links like `![image.png](../assets/...)` which may break for such filenames and for consistency should be normalized to `![image.png](<...>)`.

### Description
- Add `wrap_image_markdown_paths(text: str) -> str` in `notes_importer.py` which scans for markdown image links and wraps the destination in `<...>`, correctly handling filenames with spaces and balanced parentheses.
- Integrate the wrapper into `process_markdown` so generated asset image links are returned via `wrap_image_markdown_paths(...)` instead of raw `![image.png](../assets/...)`.
- Update existing assertion in `tests/test_notes_importer.py` to expect wrapped output and add two unit tests that verify wrapping for filenames with spaces, parenthesized filenames, plain filenames, and that already-wrapped links remain unchanged.

### Testing
- Ran the full test suite with `pytest -q` and all tests passed (9 passed in 0.21s).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a41783eec90833389057b2999d498f5)